### PR TITLE
Make CI build repeatable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,22 +11,28 @@ jobs:
           command: |
             docker create --name input --volume /home/builder/package alpine:3.7 /bin/true
             docker create --name output --volume /packages alpine:3.7 /bin/true
+            docker create --name test --volume /home/builder/package --volume /etc/apk/keys alpine:3.7 /bin/true
             docker cp ./APKBUILD input:/home/builder/package
       - run:
           name: Build packages
           command: |
             docker run --env RSA_PRIVATE_KEY="$RSA_PRIVATE_KEY" --env RSA_PRIVATE_KEY_NAME="$CIRCLE_PROJECT_USERNAME.rsa" \
-                       --volumes-from input --volumes-from output $CIRCLE_PROJECT_USERNAME/alpine-abuild:v6
+                       --volumes-from input --volumes-from output sgerrand/alpine-abuild:3.7
       - run:
           name: Extract packages
           command: |
             mkdir -p packages
             docker cp output:/packages/builder packages/
       - run:
+          name: Copy files
+          command: |
+            docker cp sgerrand.rsa.pub test:/etc/apk/keys/
+            docker cp packages/builder test:/packages/builder
+      - run:
           name: Test installing packages
           command: |
-            cp $CIRCLE_PROJECT_USERNAME.rsa.pub /etc/apk/keys/$CIRCLE_PROJECT_USERNAME.rsa.pub
-            apk add --no-progress --update-cache --upgrade ./packages/builder/x86_64/php5-imagick-*.apk
+            docker run --volumes-from test alpine:3.7 \
+              apk add --no-progress --update-cache --upgrade /packages/builder/x86_64/php5-imagick-*.apk
       - run:
           name: Test PHP module
           command: |
@@ -37,6 +43,7 @@ jobs:
           command: |
             docker rm input
             docker rm output
+            docker rm test
           when: always
       - store_artifacts:
           destination: pkgs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,9 @@ jobs:
       - run:
           name: Test PHP module
           command: |
-             apk add --no-cache --no-progress php5-cli
-             php5 -r '$canvas = new Imagick(); $canvas->newImage(350, 70, "white");'
+            docker run --volumes-from test alpine:3.7 \
+              sh -c 'apk add --no-progress --update-cache --upgrade /packages/builder/x86_64/php5-imagick-*.apk \
+                && php5 -r '"'"'$canvas = new Imagick(); $canvas->newImage(350, 70, "white");'"'"''
       - run:
           name: Remove Docker volumes
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Test installing packages
           command: |
             docker run --volumes-from test alpine:3.7 \
-              apk add --no-progress --update-cache --upgrade /packages/builder/x86_64/php5-imagick-*.apk
+              sh -c 'apk add --no-progress --update-cache --upgrade /packages/builder/x86_64/php5-imagick-*.apk'
       - run:
           name: Test PHP module
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: |
             docker create --name input --volume /home/builder/package alpine:3.7 /bin/true
             docker create --name output --volume /packages alpine:3.7 /bin/true
-            docker create --name test --volume /home/builder/package --volume /etc/apk/keys alpine:3.7 /bin/true
+            docker create --name test --volume /home/builder/package --volume /etc/apk/keys --volume /packages alpine:3.7 /bin/true
             docker cp ./APKBUILD input:/home/builder/package
       - run:
           name: Build packages


### PR DESCRIPTION
💁 Using a Docker image with a floating tag like `docker:git` means that the runtime version of Alpine Linux cannot be guaranteed. Using a Docker container within this container is more reliable.