### PR TITLE
CI: support building tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,10 @@ workflows:
   version: 2
   build-test-release:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+){1,2}(\-r\d+)?$/
       - release-master:
           requires:
             - build


### PR DESCRIPTION
💁 These changes enable tags to be built as part of the CircleCI build. These previously were being ignored due to the following configuration error:

> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must use regular expressions to specify tag filters for those jobs.

https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag